### PR TITLE
added auto copy of template stylesheets

### DIFF
--- a/obsidian_html/Vault.py
+++ b/obsidian_html/Vault.py
@@ -32,9 +32,9 @@ class Vault:
 
                 self.notes[i].backlinks = render_markdown(self.notes[i].backlinks)
 
-    def export_html(self, out_dir):
 
-        # Ensure out_dir exists, as well as its sub-folders. (must be done now to copy imgs(future) and stylesheet)
+    def export_html(self, out_dir):
+        # Ensure out_dir exists, as well as its sub-folders.
         if not os.path.exists(out_dir):
             os.makedirs(out_dir)
         for folder in self.extra_folders:

--- a/obsidian_html/Vault.py
+++ b/obsidian_html/Vault.py
@@ -6,13 +6,12 @@ from obsidian_html import GLOBAL
 
 
 class Vault:
-    def __init__(self, vault_root, extra_folders=[], html_template=None, filter=[], ):
+    def __init__(self, vault_root, extra_folders=[], html_template=None, filter=[]):
         self.vault_root = vault_root
         self.filter = filter
         self.notes = self._find_files(vault_root, extra_folders)
         self.extra_folders = extra_folders
         self._add_backlinks()
-        self.stylesheet_path = ""
 
         self.html_template = html_template
         if html_template:
@@ -43,7 +42,7 @@ class Vault:
                 os.makedirs(os.path.join(out_dir, folder))
         
         # Scan html template for stylesheet
-        scan_for_stylesheet(self.stylesheet_path, self.html_template, out_dir)
+        scan_for_stylesheet(self.html_template, out_dir)
 
         for note in self.notes:
             if self.html_template:

--- a/obsidian_html/Vault.py
+++ b/obsidian_html/Vault.py
@@ -2,20 +2,57 @@ import os
 import regex as re
 from obsidian_html.utils import slug_case, md_link, render_markdown
 from obsidian_html.Note import Note
+from obsidian_html import GLOBAL
 
 
 class Vault:
-    def __init__(self, vault_root, extra_folders=[], html_template=None, filter=[]):
+    def __init__(self, vault_root, extra_folders=[], html_template=None, filter=[], out_dir=""):
         self.vault_root = vault_root
+        self.out_dir = out_dir
         self.filter = filter
         self.notes = self._find_files(vault_root, extra_folders)
         self.extra_folders = extra_folders
         self._add_backlinks()
+        self.stylesheet_path = ""
 
         self.html_template = html_template
         if html_template:
             with open(html_template, "r", encoding="utf8") as f:
                 self.html_template = f.read()
+
+        # Ensure out_dir exists, as well as its sub-folders. (must be done now to copy imgs(future) and stylesheet)
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
+        for folder in self.extra_folders:
+            if not os.path.exists(os.path.join(out_dir, folder)):
+                os.makedirs(os.path.join(out_dir, folder))
+
+        # Find if any stylesheets are linked, and if they are local
+        if GLOBAL.IGNORE_STYLESHEET == False: # Don't check if user specified ignore
+            try:
+                self.stylesheet_path = re.search('<link+.*rel="stylesheet"+.*href="(.+?)"', self.html_template).group(1)
+            except AttributeError:
+                #Then <link, rel="stylesheet", href="" wasn't found.
+                GLOBAL.IGNORE_STYLESHEET = True
+                print("Attributeerror")
+
+            if not os.path.isfile(self.stylesheet_path):
+                #Then the file referred to in the href does not exist. May be online hosted, and should be ignored.
+                GLOBAL.IGNORE_STYLESHEET = True
+                print("FileNotFoundError")
+            else:
+                #So it exists, and is local. Let's copy it to the output dir.
+                #Probably a better copy method could have been used..
+                
+                style = open(self.stylesheet_path, "r") #open file
+                self.stylesheet_outpath = os.path.join(out_dir, os.path.basename(self.stylesheet_path)) #set out path
+                print("Copying " + self.stylesheet_path + " to: " + self.stylesheet_outpath)
+                savestyle = open(self.stylesheet_outpath, 'w') #open out file
+                savestyle.write(style.read())   #write out file
+                style.close()
+                savestyle.close()
+
+
 
     def _add_backlinks(self):
         for i, note in enumerate(self.notes):
@@ -30,20 +67,25 @@ class Vault:
 
                 self.notes[i].backlinks = render_markdown(self.notes[i].backlinks)
 
-    def export_html(self, out_dir):
-        # Ensure out_dir exists, as well as its sub-folders.
-        if not os.path.exists(out_dir):
-            os.makedirs(out_dir)
-        for folder in self.extra_folders:
-            if not os.path.exists(os.path.join(out_dir, folder)):
-                os.makedirs(os.path.join(out_dir, folder))
+    def export_html(self):
+        
 
         for note in self.notes:
             if self.html_template:
                 html = self.html_template.format(title=note.title, content=note.html(), backlinks=note.backlinks)
+                
+                # Replace stylesheet href with correct relative path
+                if GLOBAL.IGNORE_STYLESHEET == False:
+                    relative_stylesheet_path = os.path.relpath(self.stylesheet_outpath, start = self.out_dir)
+                    #Scanning to find the match and replace with new file
+                    match = re.search('<link+.*rel="stylesheet"+.*href="(.+?)"', html)
+                    if match:
+                        replacement = re.sub(match.group(1), relative_stylesheet_path, match.group())
+                        html = re.sub(match.group(), replacement, html)
+                        
             else:
                 html = note.html()
-            with open(os.path.join(out_dir, note.filename_html), "w", encoding="utf8") as f:
+            with open(os.path.join(self.out_dir, note.filename_html), "w", encoding="utf8") as f:
                 f.write(html)
 
 

--- a/obsidian_html/__init__.py
+++ b/obsidian_html/__init__.py
@@ -36,8 +36,13 @@ def main():
                         action="store_true",
                         help="Whether to include a '.html' extension on links. Useful for viewing locally.")
 
+    parser.add_argument("-i", "--ignore_stylesheet",
+                        action="store_true",
+                        help="Ignores any local stylesheet referenced in the html template")
+                        
     args = parser.parse_args()
 
     GLOBAL.HTML_LINK_EXTENSIONS = args.extensions
-    vault = Vault(args.Vault, extra_folders=args.dirs, html_template=args.template, filter=args.filter)
-    vault.export_html(args.output_dir)
+    GLOBAL.IGNORE_STYLESHEET = args.ignore_stylesheet
+    vault = Vault(args.Vault, extra_folders=args.dirs, html_template=args.template, filter=args.filter, out_dir=args.output_dir)
+    vault.export_html()

--- a/obsidian_html/__init__.py
+++ b/obsidian_html/__init__.py
@@ -44,5 +44,5 @@ def main():
 
     GLOBAL.HTML_LINK_EXTENSIONS = args.extensions
     GLOBAL.IGNORE_STYLESHEET = args.ignore_stylesheet
-    vault = Vault(args.Vault, extra_folders=args.dirs, html_template=args.template, filter=args.filter, out_dir=args.output_dir)
-    vault.export_html()
+    vault = Vault(args.Vault, extra_folders=args.dirs, html_template=args.template, filter=args.filter)
+    vault.export_html(args.output_dir)

--- a/obsidian_html/config.py
+++ b/obsidian_html/config.py
@@ -1,2 +1,3 @@
 class GLOBAL:
     HTML_LINK_EXTENSIONS = False
+    IGNORE_STYLESHEET = False

--- a/obsidian_html/utils.py
+++ b/obsidian_html/utils.py
@@ -73,7 +73,7 @@ def render_markdown(text):
 
     return markdown2.markdown(text, extras=markdown2_extras)
 
-def scan_for_stylesheet(stylesheet_path,template, out_dir):
+def scan_for_stylesheet(template, out_dir):
     # Find if any stylesheets are linked, and if they are local
     if GLOBAL.IGNORE_STYLESHEET == False: # Don't check if user specified ignore
         stylesheets = []

--- a/obsidian_html/utils.py
+++ b/obsidian_html/utils.py
@@ -72,3 +72,41 @@ def render_markdown(text):
     ]
 
     return markdown2.markdown(text, extras=markdown2_extras)
+
+def scan_for_stylesheet(stylesheet_path,template, out_dir):
+    # Find if any stylesheets are linked, and if they are local
+    if GLOBAL.IGNORE_STYLESHEET == False: # Don't check if user specified ignore
+        stylesheets = []
+        try:
+            stylesheets = re.findall('<link+.*rel="stylesheet"+.*href="(.+?)"', template)
+        except AttributeError:
+            #Then <link, rel="stylesheet", href="" wasn't found.
+            GLOBAL.IGNORE_STYLESHEET = True
+
+        for stylesheet in stylesheets:
+            if not os.path.isfile(stylesheet):
+                #Then the file referred to in the href does not exist. May be online hosted, and should be ignored.
+                GLOBAL.IGNORE_STYLESHEET = True
+                print("Info: " + stylesheet + " from html template not found locally.")
+            else:
+                #So it exists, and is local. Let's copy it to the output dir.
+                #Probably a better copy method could have been used..
+                style = open(stylesheet, "r") #open file
+                stylesheet_outpath = os.path.join(out_dir, os.path.basename(stylesheet)) #set out path
+                print("Copying " + stylesheet + " to: " + stylesheet_outpath)
+                savestyle = open(stylesheet_outpath, 'w') #open out file
+                savestyle.write(style.read())   #write out file
+                style.close()
+                savestyle.close()
+
+def replace_stylesheet_html(html, out_dir, file_out_dir):
+    # Replace stylesheet href with correct relative path
+    if GLOBAL.IGNORE_STYLESHEET == False:
+        relative_stylesheet_path = os.path.relpath(out_dir, start = file_out_dir)
+        #Scanning to find the match and replace with new file
+        match = re.search('<link+.*rel="stylesheet"+.*href="(.+?)"', html)
+        if match:
+            replacement = re.sub(match.group(1), relative_stylesheet_path, match.group())
+            html = re.sub(match.group(), replacement, html)
+
+    return html

--- a/obsidian_html/utils.py
+++ b/obsidian_html/utils.py
@@ -37,12 +37,14 @@ def find_backlinks(target_note_name, all_notes):
 
     return backlinks
 
+
 def find_tags(document):
     tags = [match.group(1) for match in re.finditer(r"\s#([\p{L}_-]+)", document)]
     # Sort by length (longest first) to fix issues pertaining to tags beginning with the same word.
     tags.sort(key=lambda x: len(x), reverse=True)
     
     return tags
+
 
 def render_markdown(text):
     # Escaped curly braces lose their escapes when formatted. I'm suspecting
@@ -73,6 +75,7 @@ def render_markdown(text):
 
     return markdown2.markdown(text, extras=markdown2_extras)
 
+
 def scan_for_stylesheet(template, out_dir):
     # Find if any stylesheets are linked, and if they are local
     if GLOBAL.IGNORE_STYLESHEET == False: # Don't check if user specified ignore
@@ -98,6 +101,7 @@ def scan_for_stylesheet(template, out_dir):
                 savestyle.write(style.read())   #write out file
                 style.close()
                 savestyle.close()
+
 
 def replace_stylesheet_html(html, out_dir, file_out_dir):
     # Replace stylesheet href with correct relative path


### PR DESCRIPTION
added two new functions in utils (was this the correct place?) which is called from the export_html function when running.
Added user argument -i (--ignore_stylesheet) which allows the user to avoid copying and scanning for stylesheet
Added new global argument to support --ignore_stylesheet
