### PR TITLE
fix(block refs): remove block id from slug end

### DIFF
--- a/oboe/Link.py
+++ b/oboe/Link.py
@@ -33,6 +33,13 @@ class Link:
             self.content = self.get_content()
 
         self.slug = "/".join(list(map(lambda x: slug_case(x), text.split("/"))))
+        if hasattr(self, "blockref"):
+            ref = getattr(self, "blockref")
+            # the slug ends up with the block ref id appended
+            # eg. my-noteBLOCKID
+            # this breaks blockref links
+            # so we need to remove it
+            self.slug = re.sub("%s$" % ref, "", self.slug)
 
 
     def get_content(self):

--- a/oboe/Link.py
+++ b/oboe/Link.py
@@ -32,14 +32,7 @@ class Link:
             # Is embed, run function to get the content of the link destination
             self.content = self.get_content()
 
-        self.slug = "/".join(list(map(lambda x: slug_case(x), text.split("/"))))
-        if hasattr(self, "blockref"):
-            ref = getattr(self, "blockref")
-            # the slug ends up with the block ref id appended
-            # eg. my-noteBLOCKID
-            # this breaks blockref links
-            # so we need to remove it
-            self.slug = re.sub("%s$" % ref, "", self.slug)
+        self.slug = "/".join(list(map(lambda x: slug_case(x), self.path.split(os.path.sep))))
 
 
     def get_content(self):
@@ -64,3 +57,6 @@ class Link:
 
     def __eq__(self, other):
         return self.path == other.path
+
+if __name__ == "__main__":
+    l = Link("file#^blockref")


### PR DESCRIPTION
The block ref slug is left with the block ref id at the end
eg `my-noteBLOCKID`
This breaks block ref links

This PR removes that block id from the slug so the links work.

### Full Example

For note: `first-note`
with block: `8db431`

The slug becomes: `first-note8db431`
And the href becomes: `first-note8db431.html#8db431`

Where there is no file `first-note8db431.html`